### PR TITLE
Add flip cards to testimonials and theme provider

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -6,6 +6,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { ThemeProvider } from "next-themes";
 import Index from "./pages/Index";
 import About from "./pages/About";
 import NotFound from "./pages/NotFound";
@@ -19,42 +20,44 @@ import ScrollToTop from "./components/ui/ScrollToTop";
 const queryClient = new QueryClient();
 
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <WaterBackground />
-        <div className="app-content-over-water">
-          <NavBar />
-          <ScrollToTop />
-          <Routes>
-            {/* Root (no locale) */}
-            <Route path="/" element={<Index />} />
+  <ThemeProvider attribute="class" defaultTheme="system">
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <WaterBackground />
+          <div className="app-content-over-water">
+            <NavBar />
+            <ScrollToTop />
+            <Routes>
+              {/* Root (no locale) */}
+              <Route path="/" element={<Index />} />
 
-            {/* Locale prefixed routes (e.g. /en, /hin, /mar) */}
-            <Route path="/:lang" element={<Index />} />
-            <Route path="/:lang/about-us" element={<About />} />
+              {/* Locale prefixed routes (e.g. /en, /hin, /mar) */}
+              <Route path="/:lang" element={<Index />} />
+              <Route path="/:lang/about-us" element={<About />} />
 
-            {/* Product pages */}
-            <Route path="/:lang/products/:product" element={<Product />} />
-            <Route path="/products/:product" element={<Product />} />
+              {/* Product pages */}
+              <Route path="/:lang/products/:product" element={<Product />} />
+              <Route path="/products/:product" element={<Product />} />
 
-            {/* Partner pages */}
-            <Route path="/:lang/partner/:partner" element={<Partner />} />
-            <Route path="/partner/:partner" element={<Partner />} />
+              {/* Partner pages */}
+              <Route path="/:lang/partner/:partner" element={<Partner />} />
+              <Route path="/partner/:partner" element={<Partner />} />
 
-            {/* Legacy paths */}
-            <Route path="/about" element={<About />} />
+              {/* Legacy paths */}
+              <Route path="/about" element={<About />} />
 
-            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-          <Footer />
-        </div>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+            <Footer />
+          </div>
+        </BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  </ThemeProvider>
 );
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/client/components/ui/AwardsMarquee.tsx
+++ b/client/components/ui/AwardsMarquee.tsx
@@ -55,7 +55,7 @@ export default function AwardsMarquee() {
   const items = [...awards, ...awards]; // duplicate for seamless loop
 
   return (
-    <section className="">
+    <section className="mb-10">
       <div className="max-w-7xl mx-auto px-6 md:px-12">
         <div className="text-center mb-6">
           <p className="text-sm text-slate-500 tracking-wide">

--- a/client/components/ui/CardCarousel.tsx
+++ b/client/components/ui/CardCarousel.tsx
@@ -80,6 +80,8 @@ export default function CardCarousel({
   const rafRef = useRef<number | null>(null);
   const [isPaused, setIsPaused] = useState(false);
   const suppressRef = useRef(0); // timestamp to suppress automatic active updates during programmatic scrolls
+  const [flipped, setFlipped] = useState<Record<string, boolean>>({});
+  const toggleFlip = (id: string) => setFlipped((p) => ({ ...p, [id]: !p[id] }));
 
   useEffect(() => {
     if (isPaused) return;

--- a/client/components/ui/CardCarousel.tsx
+++ b/client/components/ui/CardCarousel.tsx
@@ -203,7 +203,7 @@ export default function CardCarousel({
                     className={`mx-2 rounded-[14px] border border-[#E5E7EB] p-6 h-full transition-colors duration-300 ease-out ${
                       isActive ? "bg-[#ffe1ce] text-black" : "bg-white text-black"
                     }`}
-                    style={{ minHeight: 260 }}
+                    style={{ minHeight: 384 }}
                   >
                     {enableFlip ? (
                       <div className="relative w-full h-full" style={{ perspective: 1000 }}>

--- a/client/components/ui/CardCarousel.tsx
+++ b/client/components/ui/CardCarousel.tsx
@@ -200,66 +200,161 @@ export default function CardCarousel({
                   aria-hidden={false}
                 >
                   <article
-                    className={`mx-2 rounded-[14px] border border-[#E5E7EB] p-6 flex flex-col items-center text-center h-full transition-colors duration-300 ease-out ${
-                      isActive
-                        ? "bg-[#ffe1ce] text-black"
-                        : "bg-white text-black"
+                    className={`mx-2 rounded-[14px] border border-[#E5E7EB] p-6 h-full transition-colors duration-300 ease-out ${
+                      isActive ? "bg-[#ffe1ce] text-black" : "bg-white text-black"
                     }`}
-                    style={{ minHeight: 220 }}
+                    style={{ minHeight: 260 }}
                   >
-                    {/* Media (video/image) or icon */}
-                    {c.media ? (
-                      c.media.type === "video" ? (
-                        <div className="mb-4 w-full rounded-lg overflow-hidden">
-                          {/(youtube\.com|youtu\.be)/.test(c.media.src) ? (
-                            <div className="relative w-full h-40">
-                              <iframe
-                                src={c.media.src}
-                                className="absolute inset-0 w-full h-full"
-                                title={c.title}
-                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                                allowFullScreen
-                              />
+                    {enableFlip ? (
+                      <div className="relative w-full h-full" style={{ perspective: 1000 }}>
+                        <div
+                          className="relative w-full h-full transition-transform duration-500"
+                          style={{
+                            transformStyle: "preserve-3d",
+                            transform: flipped[c.id] ? "rotateY(180deg)" : "rotateY(0deg)",
+                          }}
+                        >
+                          <div
+                            className="absolute inset-0 flex flex-col items-center text-center"
+                            style={{ backfaceVisibility: "hidden" }}
+                          >
+                            {c.media ? (
+                              c.media.type === "video" ? (
+                                <div className="mb-4 w-full rounded-lg overflow-hidden">
+                                  {/(youtube\.com|youtu\.be)/.test(c.media.src) ? (
+                                    <div className="relative w-full h-40">
+                                      <iframe
+                                        src={c.media.src}
+                                        className="absolute inset-0 w-full h-full"
+                                        title={c.title}
+                                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                                        allowFullScreen
+                                      />
+                                    </div>
+                                  ) : (
+                                    <video
+                                      src={c.media.src}
+                                      poster={c.media.poster}
+                                      controls
+                                      className="w-full h-40 object-cover bg-black"
+                                      preload="metadata"
+                                      playsInline
+                                    />
+                                  )}
+                                </div>
+                              ) : (
+                                <img
+                                  src={c.media.src}
+                                  alt={c.media.alt || c.title}
+                                  className="mb-4 w-full h-40 object-cover rounded-lg"
+                                />
+                              )
+                            ) : (
+                              <div className="mb-4 rounded-full p-2 inline-flex items-center justify-center text-black">
+                                {c.icon
+                                  ? // @ts-ignore
+                                    cloneElement(c.icon as React.ReactElement, {
+                                      color: "#000000",
+                                      size: 36,
+                                    })
+                                  : null}
+                              </div>
+                            )}
+
+                            <h3 className="font-semibold text-[18px] leading-tight text-black">
+                              {c.title}
+                            </h3>
+                            <p className="mt-2 text-[14px] leading-snug text-slate-700">
+                              {c.description}
+                            </p>
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                toggleFlip(c.id);
+                              }}
+                              className="mt-4 inline-flex items-center bg-[#0a66c2] text-white rounded-full px-4 py-2 text-sm font-semibold hover:bg-[#084a9e]"
+                            >
+                              More
+                            </button>
+                          </div>
+
+                          <div
+                            className="absolute inset-0 flex flex-col items-center justify-center text-center p-4"
+                            style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
+                          >
+                            <h3 className="font-semibold text-[18px] leading-tight text-black">
+                              {c.title}
+                            </h3>
+                            <p className="mt-2 text-[14px] leading-snug text-slate-700">
+                              {c.description}
+                            </p>
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                toggleFlip(c.id);
+                              }}
+                              className="mt-4 inline-flex items-center border border-slate-300 text-slate-800 rounded-full px-4 py-2 text-sm font-semibold hover:bg-slate-50"
+                            >
+                              Back
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex flex-col items-center text-center">
+                        {c.media ? (
+                          c.media.type === "video" ? (
+                            <div className="mb-4 w-full rounded-lg overflow-hidden">
+                              {/(youtube\.com|youtu\.be)/.test(c.media.src) ? (
+                                <div className="relative w-full h-40">
+                                  <iframe
+                                    src={c.media.src}
+                                    className="absolute inset-0 w-full h-full"
+                                    title={c.title}
+                                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                                    allowFullScreen
+                                  />
+                                </div>
+                              ) : (
+                                <video
+                                  src={c.media.src}
+                                  poster={c.media.poster}
+                                  controls
+                                  className="w-full h-40 object-cover bg-black"
+                                  preload="metadata"
+                                  playsInline
+                                />
+                              )}
                             </div>
                           ) : (
-                            <video
+                            <img
                               src={c.media.src}
-                              poster={c.media.poster}
-                              controls
-                              className="w-full h-40 object-cover bg-black"
-                              preload="metadata"
-                              playsInline
+                              alt={c.media.alt || c.title}
+                              className="mb-4 w-full h-40 object-cover rounded-lg"
                             />
-                          )}
-                        </div>
-                      ) : (
-                        <img
-                          src={c.media.src}
-                          alt={c.media.alt || c.title}
-                          className="mb-4 w-full h-40 object-cover rounded-lg"
-                        />
-                      )
-                    ) : (
-                      <div
-                        className={`mb-4 rounded-full p-2 inline-flex items-center justify-center transition-colors duration-300 ease-out text-black`}
-                      >
-                        {/* Icon color inherits currentColor */}
-                        {c.icon
-                          ? // @ts-ignore
-                            cloneElement(c.icon as React.ReactElement, {
-                              color: "#000000",
-                              size: 36,
-                            })
-                          : null}
+                          )
+                        ) : (
+                          <div className="mb-4 rounded-full p-2 inline-flex items-center justify-center text-black">
+                            {c.icon
+                              ? // @ts-ignore
+                                cloneElement(c.icon as React.ReactElement, {
+                                  color: "#000000",
+                                  size: 36,
+                                })
+                              : null}
+                          </div>
+                        )}
+
+                        <h3 className="font-semibold text-[18px] leading-tight text-black">
+                          {c.title}
+                        </h3>
+                        <p className="mt-2 text-[14px] leading-snug text-slate-700">
+                          {c.description}
+                        </p>
                       </div>
                     )}
-
-                    <h3 className="font-semibold text-[18px] leading-tight text-black">
-                      {c.title}
-                    </h3>
-                    <p className="mt-2 text-[14px] leading-snug text-slate-700">
-                      {c.description}
-                    </p>
                   </article>
                 </div>
               );

--- a/client/components/ui/CardCarousel.tsx
+++ b/client/components/ui/CardCarousel.tsx
@@ -81,7 +81,8 @@ export default function CardCarousel({
   const [isPaused, setIsPaused] = useState(false);
   const suppressRef = useRef(0); // timestamp to suppress automatic active updates during programmatic scrolls
   const [flipped, setFlipped] = useState<Record<string, boolean>>({});
-  const toggleFlip = (id: string) => setFlipped((p) => ({ ...p, [id]: !p[id] }));
+  const toggleFlip = (id: string) =>
+    setFlipped((p) => ({ ...p, [id]: !p[id] }));
 
   useEffect(() => {
     if (isPaused) return;
@@ -201,17 +202,24 @@ export default function CardCarousel({
                 >
                   <article
                     className={`mx-2 rounded-[14px] border border-[#E5E7EB] p-6 h-full transition-colors duration-300 ease-out ${
-                      isActive ? "bg-[#ffe1ce] text-black" : "bg-white text-black"
+                      isActive
+                        ? "bg-[#ffe1ce] text-black"
+                        : "bg-white text-black"
                     }`}
                     style={{ minHeight: 384 }}
                   >
                     {enableFlip ? (
-                      <div className="relative w-full h-full" style={{ perspective: 1000 }}>
+                      <div
+                        className="relative w-full h-full"
+                        style={{ perspective: 1000 }}
+                      >
                         <div
                           className="relative w-full h-full transition-transform duration-500"
                           style={{
                             transformStyle: "preserve-3d",
-                            transform: flipped[c.id] ? "rotateY(180deg)" : "rotateY(0deg)",
+                            transform: flipped[c.id]
+                              ? "rotateY(180deg)"
+                              : "rotateY(0deg)",
                           }}
                         >
                           <div
@@ -221,7 +229,9 @@ export default function CardCarousel({
                             {c.media ? (
                               c.media.type === "video" ? (
                                 <div className="mb-4 w-full rounded-lg overflow-hidden">
-                                  {/(youtube\.com|youtu\.be)/.test(c.media.src) ? (
+                                  {/(youtube\.com|youtu\.be)/.test(
+                                    c.media.src,
+                                  ) ? (
                                     <div className="relative w-full h-64">
                                       <iframe
                                         src={c.media.src}
@@ -278,7 +288,10 @@ export default function CardCarousel({
 
                           <div
                             className="absolute inset-0 flex flex-col items-center justify-center text-center p-4"
-                            style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
+                            style={{
+                              backfaceVisibility: "hidden",
+                              transform: "rotateY(180deg)",
+                            }}
                           >
                             <h3 className="font-semibold text-[18px] leading-tight text-black">
                               {c.title}

--- a/client/components/ui/CardCarousel.tsx
+++ b/client/components/ui/CardCarousel.tsx
@@ -69,9 +69,11 @@ const sampleCards: CardData[] = [
 export default function CardCarousel({
   cards = sampleCards,
   showTitle = false,
+  enableFlip = false,
 }: {
   cards?: CardData[];
   showTitle?: boolean;
+  enableFlip?: boolean;
 }) {
   const scrollerRef = useRef<HTMLDivElement | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);

--- a/client/components/ui/CardCarousel.tsx
+++ b/client/components/ui/CardCarousel.tsx
@@ -236,7 +236,7 @@ export default function CardCarousel({
                                       src={c.media.src}
                                       poster={c.media.poster}
                                       controls
-                                      className="w-full h-40 object-cover bg-black"
+                                      className="w-full h-64 object-cover bg-black"
                                       preload="metadata"
                                       playsInline
                                     />
@@ -246,7 +246,7 @@ export default function CardCarousel({
                                 <img
                                   src={c.media.src}
                                   alt={c.media.alt || c.title}
-                                  className="mb-4 w-full h-40 object-cover rounded-lg"
+                                  className="mb-4 w-full h-64 object-cover rounded-lg"
                                 />
                               )
                             ) : (
@@ -322,7 +322,7 @@ export default function CardCarousel({
                                   src={c.media.src}
                                   poster={c.media.poster}
                                   controls
-                                  className="w-full h-40 object-cover bg-black"
+                                  className="w-full h-64 object-cover bg-black"
                                   preload="metadata"
                                   playsInline
                                 />
@@ -332,7 +332,7 @@ export default function CardCarousel({
                             <img
                               src={c.media.src}
                               alt={c.media.alt || c.title}
-                              className="mb-4 w-full h-40 object-cover rounded-lg"
+                              className="mb-4 w-full h-64 object-cover rounded-lg"
                             />
                           )
                         ) : (

--- a/client/components/ui/CardCarousel.tsx
+++ b/client/components/ui/CardCarousel.tsx
@@ -207,14 +207,26 @@ export default function CardCarousel({
                     {c.media ? (
                       c.media.type === "video" ? (
                         <div className="mb-4 w-full rounded-lg overflow-hidden">
-                          <video
-                            src={c.media.src}
-                            poster={c.media.poster}
-                            controls
-                            className="w-full h-40 object-cover bg-black"
-                            preload="metadata"
-                            playsInline
-                          />
+                          {/(youtube\.com|youtu\.be)/.test(c.media.src) ? (
+                            <div className="relative w-full h-40">
+                              <iframe
+                                src={c.media.src}
+                                className="absolute inset-0 w-full h-full"
+                                title={c.title}
+                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                                allowFullScreen
+                              />
+                            </div>
+                          ) : (
+                            <video
+                              src={c.media.src}
+                              poster={c.media.poster}
+                              controls
+                              className="w-full h-40 object-cover bg-black"
+                              preload="metadata"
+                              playsInline
+                            />
+                          )}
                         </div>
                       ) : (
                         <img

--- a/client/components/ui/CardCarousel.tsx
+++ b/client/components/ui/CardCarousel.tsx
@@ -222,7 +222,7 @@ export default function CardCarousel({
                               c.media.type === "video" ? (
                                 <div className="mb-4 w-full rounded-lg overflow-hidden">
                                   {/(youtube\.com|youtu\.be)/.test(c.media.src) ? (
-                                    <div className="relative w-full h-40">
+                                    <div className="relative w-full h-64">
                                       <iframe
                                         src={c.media.src}
                                         className="absolute inset-0 w-full h-full"
@@ -308,7 +308,7 @@ export default function CardCarousel({
                           c.media.type === "video" ? (
                             <div className="mb-4 w-full rounded-lg overflow-hidden">
                               {/(youtube\.com|youtu\.be)/.test(c.media.src) ? (
-                                <div className="relative w-full h-40">
+                                <div className="relative w-full h-64">
                                   <iframe
                                     src={c.media.src}
                                     className="absolute inset-0 w-full h-full"

--- a/client/components/ui/CardCarousel.tsx
+++ b/client/components/ui/CardCarousel.tsx
@@ -264,9 +264,6 @@ export default function CardCarousel({
                             <h3 className="font-semibold text-[18px] leading-tight text-black">
                               {c.title}
                             </h3>
-                            <p className="mt-2 text-[14px] leading-snug text-slate-700">
-                              {c.description}
-                            </p>
                             <button
                               type="button"
                               onClick={(e) => {

--- a/client/components/ui/Footer.tsx
+++ b/client/components/ui/Footer.tsx
@@ -1,7 +1,5 @@
 import { Link } from "react-router-dom";
 
-import { Link } from "react-router-dom";
-
 export default function Footer() {
   return (
     <footer className="bg-[#0D3B66] text-white">
@@ -19,15 +17,21 @@ export default function Footer() {
 
             <div className="mt-4 flex items-center gap-3">
               <a
-                href={
-                  'https://play.google.com/store/apps/details?id=com.nivesh.production" target="_blank"><img src="/b1e0ea7105b59c39914f42a97c0927eb.svg" alt="" class="img-responsive2'
-                }
-              ></a>
+                href="https://play.google.com/store/apps/details?id=com.nivesh.production"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline text-white/90 hover:text-white"
+              >
+                Get it on Google Play
+              </a>
               <a
-                href={
-                  'https://apps.apple.com/in/app/nivesh-wealth-management-app/id6740700135" target="_blank"><img src="/39662a6f385663aae1cec89625b9f278.svg" alt="" class="img-responsive2'
-                }
-              ></a>
+                href="https://apps.apple.com/in/app/nivesh-wealth-management-app/id6740700135"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline text-white/90 hover:text-white"
+              >
+                Download on the App Store
+              </a>
             </div>
           </div>
 
@@ -36,7 +40,7 @@ export default function Footer() {
             <h4 className="text-white font-semibold mb-4">Quick Links</h4>
             <ul className="text-sm space-y-2 text-white/90">
               <li className="mb-2">
-                <Link to="/about-us" className="hover:underline">
+                <Link to="/about" className="hover:underline">
                   About Us
                 </Link>
               </li>
@@ -62,7 +66,7 @@ export default function Footer() {
               </li>
               <li className="mb-2">
                 <Link to="/terms" className="hover:underline">
-                  Terms &amp; Conditions
+                  Terms & Conditions
                 </Link>
               </li>
               <li className="mb-2">
@@ -104,37 +108,27 @@ export default function Footer() {
               <li className="mb-2">AMFI ARN Code</li>
             </ul>
 
-            <div className="mt-6 flex items-center gap-3">
-              {/* social icons */}
-              <a href="https://twitter.com/niveshapp" target="_blank">
-                <i class="fa-brands fa-x-twitter"></i>
+            <div className="mt-6 flex items-center gap-3 text-sm">
+              <a href="https://twitter.com/niveshapp" target="_blank" rel="noopener noreferrer" className="hover:underline">
+                Twitter
               </a>
-              <a
-                href="https://www.instagram.com/nivesh__official?igsh=MXg5NXR2Mjl0ODAwbw%3D%3D"
-                target="_blank"
-              >
-                <i class="fa-brands fa-instagram"></i>
+              <a href="https://www.instagram.com/nivesh__official?igsh=MXg5NXR2Mjl0ODAwbw%3D%3D" target="_blank" rel="noopener noreferrer" className="hover:underline">
+                Instagram
               </a>
-              <a href="https://www.facebook.com/niveshapp/" target="_blank">
-                <i class="fa-brands fa-facebook-f"></i>
+              <a href="https://www.facebook.com/niveshapp/" target="_blank" rel="noopener noreferrer" className="hover:underline">
+                Facebook
               </a>
-              <a
-                href="https://www.linkedin.com/company/nivesh/"
-                target="_blank"
-              >
-                <i class="fa-brands fa-linkedin-in"></i>
+              <a href="https://www.linkedin.com/company/nivesh/" target="_blank" rel="noopener noreferrer" className="hover:underline">
+                LinkedIn
               </a>
-              <a
-                href="https://www.youtube.com/c/NiveshOfficial/channels"
-                target="_blank"
-              >
-                <i class="fa-brands fa-youtube"></i>
+              <a href="https://www.youtube.com/c/NiveshOfficial/channels" target="_blank" rel="noopener noreferrer" className="hover:underline">
+                YouTube
               </a>
             </div>
           </div>
         </div>
 
-        {/* Certifications */}
+        {/* Legal / Disclaimer */}
         <div className="mt-10 border-t border-white/10 pt-8">
           <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-6 items-start text-center">
             <div className="flex flex-col items-center gap-3">
@@ -144,9 +138,7 @@ export default function Footer() {
                 className="h-12 object-contain"
               />
               <div className="text-sm text-white/90">
-                <div className="font-semibold">
-                  Association of Mutual Funds in India
-                </div>
+                <div className="font-semibold">Association of Mutual Funds in India</div>
                 <div>Registered Mutual Fund Distributor</div>
                 <div className="mt-1">ARN: 115287</div>
               </div>
@@ -181,11 +173,7 @@ export default function Footer() {
         {/* Legal / Disclaimer */}
         <div className="mt-8 pt-8 border-t border-white/10 text-center text-xs text-white/70">
           <p className="max-w-4xl mx-auto">
-            Mutual fund investments are subject to market risks. Please read the
-            scheme information and other related documents carefully before
-            investing. Past performance is not indicative of future returns.
-            Please consider your specific investment requirements before
-            choosing a fund, or designing a portfolio that suits your needs.
+            Mutual fund investments are subject to market risks. Please read the scheme information and other related documents carefully before investing. Past performance is not indicative of future returns. Please consider your specific investment requirements before choosing a fund, or designing a portfolio that suits your needs.
           </p>
           <p className="mt-4">© Providential Platforms Pvt. Ltd.</p>
         </div>

--- a/client/components/ui/ImageBenefits.tsx
+++ b/client/components/ui/ImageBenefits.tsx
@@ -67,7 +67,7 @@ export default function ImageBenefits() {
             />
 
             {/* Content */}
-            <div className="relative h-56 flex items-end">
+            <div className="relative h-68 flex items-end">
               <div className="w-full p-5">
                 <h3 className="text-lg font-bold text-white drop-shadow-sm">
                   {c.title}

--- a/client/components/ui/ImageBenefits.tsx
+++ b/client/components/ui/ImageBenefits.tsx
@@ -12,34 +12,26 @@ const cards: Card[] = [
   {
     id: "save-tax",
     title: "Save Tax",
-    body:
-      "Plan your finances in such a way that you can reduce your tax liability through appropriate investments.",
-    image:
-      "https://cdn.builder.io/api/v1/image/assets%2Fb39648aab450460597500936af6bdfd7%2F841e973aa60e462e81a4ac5fcae238e7?format=webp&width=800",
+    body: "Plan your finances in such a way that you can reduce your tax liability through appropriate investments.",
+    image: "https://nivesh.com/45ba2ef3421d8c6816b18285bf9511e8.webp",
   },
   {
     id: "retirement",
     title: "Retirement Plan",
-    body:
-      "Secure your old age by planning ahead and building a desired retirement corpus that covers your expenses.",
-    image:
-      "https://cdn.builder.io/api/v1/image/assets%2Fb39648aab450460597500936af6bdfd7%2Fc3847e2c6d4047789fd7c6ae0fef3a7c?format=webp&width=800",
+    body: "Secure your old age by planning ahead and building a desired retirement corpus that covers your expenses.",
+    image: "https://nivesh.com/90728e03819ffa7da67a4fdb92b1a9e6.webp",
   },
   {
     id: "long-term-wealth-1",
     title: "Build Long Term Wealth",
-    body:
-      "With Nivesh you can plan your investments in such a way to build wealth for important goals.",
-    image:
-      "https://cdn.builder.io/api/v1/image/assets%2Fb39648aab450460597500936af6bdfd7%2Faba32a8ff9114f7e90b27902f2a5c7b3?format=webp&width=800",
+    body: "With Nivesh you can plan your investments in such a way to build wealth for important goals.",
+    image: "https://nivesh.com/700391d1585c35492404045ea346a185.webp",
   },
   {
     id: "long-term-wealth-2",
     title: "Build Long Term Wealth",
-    body:
-      "Invest for long-term compounding such as a house, car, marriage, or education.",
-    image:
-      "https://cdn.builder.io/api/v1/image/assets%2Fb39648aab450460597500936af6bdfd7%2Faca00b8e6b6849ff88f6af6426eb21eb?format=webp&width=800",
+    body: "Invest for long-term compounding such as a house, car, marriage, or education.",
+    image: "https://nivesh.com/4e1f095e6a20fdc2c4e1086470ea0bf3.webp",
   },
 ];
 
@@ -69,7 +61,10 @@ export default function ImageBenefits() {
               aria-hidden
             />
             {/* Dark overlay for readability */}
-            <div className="absolute inset-0 bg-black/35 group-hover:bg-black/30 transition-colors" aria-hidden />
+            <div
+              className="absolute inset-0 bg-black/35 group-hover:bg-black/30 transition-colors"
+              aria-hidden
+            />
 
             {/* Content */}
             <div className="relative h-56 flex items-end">

--- a/client/components/ui/ImageBenefits.tsx
+++ b/client/components/ui/ImageBenefits.tsx
@@ -67,7 +67,7 @@ export default function ImageBenefits() {
             />
 
             {/* Content */}
-            <div className="relative h-56 flex items-end">
+            <div className="relative h-60 flex items-end">
               <div className="w-full p-5">
                 <h3 className="text-lg font-bold text-white drop-shadow-sm">
                   {c.title}

--- a/client/components/ui/ImageBenefits.tsx
+++ b/client/components/ui/ImageBenefits.tsx
@@ -67,7 +67,7 @@ export default function ImageBenefits() {
             />
 
             {/* Content */}
-            <div className="relative h-68 flex items-end">
+            <div className="relative h-72 flex items-end">
               <div className="w-full p-5">
                 <h3 className="text-lg font-bold text-white drop-shadow-sm">
                   {c.title}

--- a/client/components/ui/ImageBenefits.tsx
+++ b/client/components/ui/ImageBenefits.tsx
@@ -55,7 +55,7 @@ export default function ImageBenefits() {
         </p>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         {cards.map((c) => (
           <article
             key={c.id}

--- a/client/components/ui/ImageBenefits.tsx
+++ b/client/components/ui/ImageBenefits.tsx
@@ -67,7 +67,7 @@ export default function ImageBenefits() {
             />
 
             {/* Content */}
-            <div className="relative h-72 flex items-end">
+            <div className="relative h-68 flex items-end">
               <div className="w-full p-5">
                 <h3 className="text-lg font-bold text-white drop-shadow-sm">
                   {c.title}

--- a/client/components/ui/ImageBenefits.tsx
+++ b/client/components/ui/ImageBenefits.tsx
@@ -67,7 +67,7 @@ export default function ImageBenefits() {
             />
 
             {/* Content */}
-            <div className="relative h-60 flex items-end">
+            <div className="relative h-56 flex items-end">
               <div className="w-full p-5">
                 <h3 className="text-lg font-bold text-white drop-shadow-sm">
                   {c.title}

--- a/client/components/ui/ImageBenefits.tsx
+++ b/client/components/ui/ImageBenefits.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+
+interface Card {
+  id: string;
+  title: string;
+  body: string;
+  image: string;
+  href?: string;
+}
+
+const cards: Card[] = [
+  {
+    id: "save-tax",
+    title: "Save Tax",
+    body:
+      "Plan your finances in such a way that you can reduce your tax liability through appropriate investments.",
+    image:
+      "https://cdn.builder.io/api/v1/image/assets%2Fb39648aab450460597500936af6bdfd7%2F841e973aa60e462e81a4ac5fcae238e7?format=webp&width=800",
+  },
+  {
+    id: "retirement",
+    title: "Retirement Plan",
+    body:
+      "Secure your old age by planning ahead and building a desired retirement corpus that covers your expenses.",
+    image:
+      "https://cdn.builder.io/api/v1/image/assets%2Fb39648aab450460597500936af6bdfd7%2Fc3847e2c6d4047789fd7c6ae0fef3a7c?format=webp&width=800",
+  },
+  {
+    id: "long-term-wealth-1",
+    title: "Build Long Term Wealth",
+    body:
+      "With Nivesh you can plan your investments in such a way to build wealth for important goals.",
+    image:
+      "https://cdn.builder.io/api/v1/image/assets%2Fb39648aab450460597500936af6bdfd7%2Faba32a8ff9114f7e90b27902f2a5c7b3?format=webp&width=800",
+  },
+  {
+    id: "long-term-wealth-2",
+    title: "Build Long Term Wealth",
+    body:
+      "Invest for long-term compounding such as a house, car, marriage, or education.",
+    image:
+      "https://cdn.builder.io/api/v1/image/assets%2Fb39648aab450460597500936af6bdfd7%2Faca00b8e6b6849ff88f6af6426eb21eb?format=webp&width=800",
+  },
+];
+
+export default function ImageBenefits() {
+  return (
+    <section className="w-full px-6 md:px-12 py-12">
+      <div className="max-w-3xl mx-auto text-center mb-6">
+        <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900">
+          Start Your Investment Journey
+        </h2>
+        <p className="text-slate-600 mt-1 text-sm md:text-base">
+          Define Your Financial Requirements
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+        {cards.map((c) => (
+          <article
+            key={c.id}
+            className="group relative rounded-2xl overflow-hidden border border-slate-200 shadow-sm bg-white"
+            aria-label={c.title}
+          >
+            {/* Background image */}
+            <div
+              className="absolute inset-0 bg-center bg-cover opacity-90 group-hover:opacity-100 transition-opacity duration-300"
+              style={{ backgroundImage: `url(${c.image})` }}
+              aria-hidden
+            />
+            {/* Dark overlay for readability */}
+            <div className="absolute inset-0 bg-black/35 group-hover:bg-black/30 transition-colors" aria-hidden />
+
+            {/* Content */}
+            <div className="relative h-56 flex items-end">
+              <div className="w-full p-5">
+                <h3 className="text-lg font-bold text-white drop-shadow-sm">
+                  {c.title}
+                </h3>
+                <p className="mt-2 text-sm text-white/90 line-clamp-3">
+                  {c.body}
+                </p>
+                <div className="mt-4">
+                  <a
+                    href={c.href || "#"}
+                    className="inline-flex items-center justify-center rounded-full bg-white/95 text-slate-900 px-4 py-2 text-xs font-semibold shadow hover:bg-white"
+                  >
+                    More
+                  </a>
+                </div>
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/client/components/ui/NavBar.tsx
+++ b/client/components/ui/NavBar.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 
 export default function NavBar() {

--- a/client/components/ui/NavBar.tsx
+++ b/client/components/ui/NavBar.tsx
@@ -1,4 +1,3 @@
-import React, { useState, useRef, useEffect } from "react";
 import React, { useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 

--- a/client/components/ui/Testimonials.tsx
+++ b/client/components/ui/Testimonials.tsx
@@ -28,13 +28,13 @@ export default function Testimonials() {
     },
     {
       id: "t3",
-      title: "Priya Kapoor — Customer Success Lead, HealthWave",
+      title: "Dhananjay Chaturvedi — Evangelist, Thinker, Consultant Formerly Managing Director, Miele India",
       description:
-        "Professional, reliable, and results-focused. Our implementation completed ahead of schedule with clear ROI.",
+        "Nivesh has changed the way I have been investing my money, they have educated me & facilitated investments into a totally new investment class for me, Mutual Funds. Having interacted with their able team, I have grown in my conviction about the merits of investing in MF’s and also benefited adequately over a period of time. Happy to recommend them to all those who are looking out for the opportunities and avenues to invest their money and see it grow.",
       media: {
         type: "image",
-        src: "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=800&q=80",
-        alt: "Priya Kapoor",
+        src: "https://nivesh.com/2d8dd1be465ff5ea58dec82a5f96ef33.webp",
+        alt: "Dhananjay Chaturvedi",
       },
     },
     {

--- a/client/components/ui/Testimonials.tsx
+++ b/client/components/ui/Testimonials.tsx
@@ -71,13 +71,13 @@ export default function Testimonials() {
             Learn why professionals trust our solutions to complete their
             customer journeys.
           </p>
-          // <div className="mt-6">
-          //   <a
-          //     href="#"
-          //     className="inline-flex items-center bg-[#0a66c2] text-white rounded-full px-5 py-3 font-medium shadow-md hover:opacity-95 hover:bg-[#084a9e] transition"
-          //     Read Success Stories →
-          //   </a>
-          // </div>
+          <div className="mt-6">
+            <a
+              href="#"
+              className="inline-flex items-center bg-[#0a66c2] text-white rounded-full px-5 py-3 font-medium shadow-md hover:opacity-95 hover:bg-[#084a9e] transition"
+              Read Success Stories →
+            </a>
+          </div>
         </div>
       </div>
     </section>

--- a/client/components/ui/Testimonials.tsx
+++ b/client/components/ui/Testimonials.tsx
@@ -57,7 +57,7 @@ export default function Testimonials() {
           Testimonials
         </h2>
         <div className="mb-6">
-          <CardCarousel cards={testimonials} />
+          <CardCarousel cards={testimonials} enableFlip />
         </div>
 
         <div className="max-w-3xl mx-auto text-center pt-6">

--- a/client/components/ui/Testimonials.tsx
+++ b/client/components/ui/Testimonials.tsx
@@ -10,7 +10,8 @@ export default function Testimonials() {
       media: {
         type: "video",
         src: "https://www.youtube.com/embed/MsBnh2RqvPg?si=iJIAWyjIqS9HzyYV",
-        poster: "https://images.unsplash.com/photo-1544005313-94ddf0286df2?auto=format&fit=crop&w=800&q=80",
+        poster:
+          "https://images.unsplash.com/photo-1544005313-94ddf0286df2?auto=format&fit=crop&w=800&q=80",
       },
     },
     {
@@ -21,7 +22,8 @@ export default function Testimonials() {
       media: {
         type: "video",
         src: "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4",
-        poster: "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=crop&w=800&q=80",
+        poster:
+          "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=crop&w=800&q=80",
       },
     },
     {
@@ -51,19 +53,32 @@ export default function Testimonials() {
   return (
     <section className="">
       <div className="relative overflow-hidden px-4 md:px-12 py-3 md:py-6">
+        <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900">
+          Testimonials
+        </h2>
         <div className="mb-6">
           <CardCarousel cards={testimonials} />
         </div>
 
         <div className="max-w-3xl mx-auto text-center pt-6">
-          <p className="text-sm text-slate-500 tracking-wide mb-2">Testimonials</p>
-          <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900">Trusted by leaders from various industries</h2>
-          <p className="mt-3 text-slate-600">Learn why professionals trust our solutions to complete their customer journeys.</p>
-          <div className="mt-6">
-            <a href="#" className="inline-flex items-center bg-[#0a66c2] text-white rounded-full px-5 py-3 font-medium shadow-md hover:opacity-95 hover:bg-[#084a9e] transition">
-              Read Success Stories →
-            </a>
-          </div>
+          <p className="text-sm text-slate-500 tracking-wide mb-2">
+            Testimonials
+          </p>
+          <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900">
+            Trusted by leaders from various industries
+          </h2>
+          <p className="mt-3 text-slate-600">
+            Learn why professionals trust our solutions to complete their
+            customer journeys.
+          </p>
+          // <div className="mt-6">
+          //   <a
+          //     href="#"
+          //     className="inline-flex items-center bg-[#0a66c2] text-white rounded-full px-5 py-3 font-medium shadow-md hover:opacity-95 hover:bg-[#084a9e] transition"
+          //   >
+          //     Read Success Stories →
+          //   </a>
+          // </div>
         </div>
       </div>
     </section>

--- a/client/components/ui/Testimonials.tsx
+++ b/client/components/ui/Testimonials.tsx
@@ -4,12 +4,12 @@ export default function Testimonials() {
   const testimonials: CardData[] = [
     {
       id: "t1",
-      title: "Aisha Rahman — VP of Product, FinCo",
+      title: "Shubham Bhatia — Nivesh Partner",
       description:
         "Working with the team accelerated our roadmap and improved customer activation across channels. Their approach is pragmatic and design-led.",
       media: {
         type: "video",
-        src: "https://www.w3schools.com/html/mov_bbb.mp4",
+        src: "https://www.youtube.com/embed/MsBnh2RqvPg?si=iJIAWyjIqS9HzyYV",
         poster: "https://images.unsplash.com/photo-1544005313-94ddf0286df2?auto=format&fit=crop&w=800&q=80",
       },
     },

--- a/client/components/ui/Testimonials.tsx
+++ b/client/components/ui/Testimonials.tsx
@@ -53,7 +53,7 @@ export default function Testimonials() {
   return (
     <section className="">
       <div className="relative overflow-hidden px-4 md:px-12 py-3 md:py-6">
-        <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900">
+        <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900 text-center">
           Testimonials
         </h2>
         <div className="mb-6">
@@ -61,9 +61,6 @@ export default function Testimonials() {
         </div>
 
         <div className="max-w-3xl mx-auto text-center pt-6">
-          <p className="text-sm text-slate-500 tracking-wide mb-2">
-            Testimonials
-          </p>
           <h2 className="text-2xl md:text-3xl font-extrabold text-slate-900">
             Trusted by leaders from various industries
           </h2>

--- a/client/components/ui/Testimonials.tsx
+++ b/client/components/ui/Testimonials.tsx
@@ -71,13 +71,6 @@ export default function Testimonials() {
             Learn why professionals trust our solutions to complete their
             customer journeys.
           </p>
-          <div className="mt-6">
-            <a
-              href="#"
-              className="inline-flex items-center bg-[#0a66c2] text-white rounded-full px-5 py-3 font-medium shadow-md hover:opacity-95 hover:bg-[#084a9e] transition"
-              Read Success Stories →
-            </a>
-          </div>
         </div>
       </div>
     </section>

--- a/client/components/ui/Testimonials.tsx
+++ b/client/components/ui/Testimonials.tsx
@@ -10,8 +10,7 @@ export default function Testimonials() {
       media: {
         type: "video",
         src: "https://www.youtube.com/embed/MsBnh2RqvPg?si=iJIAWyjIqS9HzyYV",
-        poster:
-          "https://www.youtube.com/embed/MsBnh2RqvPg?si=iJIAWyjIqS9HzyYV",
+        poster: "https://www.youtube.com/embed/MsBnh2RqvPg?si=iJIAWyjIqS9HzyYV",
       },
     },
     {
@@ -28,7 +27,8 @@ export default function Testimonials() {
     },
     {
       id: "t3",
-      title: "Dhananjay Chaturvedi — Evangelist, Thinker, Consultant Formerly Managing Director, Miele India",
+      title:
+        "Dhananjay Chaturvedi — Evangelist, Thinker, Consultant Formerly Managing Director, Miele India",
       description:
         "Nivesh has changed the way I have been investing my money, they have educated me & facilitated investments into a totally new investment class for me, Mutual Funds. Having interacted with their able team, I have grown in my conviction about the merits of investing in MF’s and also benefited adequately over a period of time. Happy to recommend them to all those who are looking out for the opportunities and avenues to invest their money and see it grow.",
       media: {

--- a/client/components/ui/Testimonials.tsx
+++ b/client/components/ui/Testimonials.tsx
@@ -11,7 +11,7 @@ export default function Testimonials() {
         type: "video",
         src: "https://www.youtube.com/embed/MsBnh2RqvPg?si=iJIAWyjIqS9HzyYV",
         poster:
-          "https://images.unsplash.com/photo-1544005313-94ddf0286df2?auto=format&fit=crop&w=800&q=80",
+          "https://www.youtube.com/embed/MsBnh2RqvPg?si=iJIAWyjIqS9HzyYV",
       },
     },
     {

--- a/client/components/ui/Testimonials.tsx
+++ b/client/components/ui/Testimonials.tsx
@@ -75,7 +75,6 @@ export default function Testimonials() {
           //   <a
           //     href="#"
           //     className="inline-flex items-center bg-[#0a66c2] text-white rounded-full px-5 py-3 font-medium shadow-md hover:opacity-95 hover:bg-[#084a9e] transition"
-          //   >
           //     Read Success Stories →
           //   </a>
           // </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -6,6 +6,7 @@ import AwardsMarquee from "@/components/ui/AwardsMarquee";
 import Testimonials from "@/components/ui/Testimonials";
 import { useParams, useLocation } from "react-router-dom";
 import Hero from "@/components/ui/Hero";
+import ImageBenefits from "@/components/ui/ImageBenefits";
 
 const translations: any = {
   en: {
@@ -17,7 +18,7 @@ const translations: any = {
   hin: {
     heroTitle: "विभिन्न उद्योगों के नेताओं द्वारा भरोसा किया गया",
     heroSubtitle:
-      "जानें कि पेशेवर अपने ग्राहक यात्रा को पूरा करने क�� लिए हमारे समाधानों पर भरोसा ���्यों करते हैं।",
+      "जानें कि पेशेवर अपने ग्राहक यात्रा को पूरा ���रने क�� लिए हमारे समाधानों पर भरोसा क्यों करते हैं।",
     cta: "सफलता की कहानियाँ पढ़ें →",
   },
   mar: {

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -17,7 +17,7 @@ const translations: any = {
   hin: {
     heroTitle: "विभिन्न उद्योगों के नेताओं द्वारा भरोसा किया गया",
     heroSubtitle:
-      "जानें कि पेशेवर अपने ग्राहक यात्रा को पूरा करने क�� लिए हमारे समाधानों पर भरोसा क्यों करते हैं।",
+      "जानें कि पेशेवर अपने ग्राहक यात्रा को पूरा करने क�� लिए हमारे समाधानों पर भरोसा ���्यों करते हैं।",
     cta: "सफलता की कहानियाँ पढ़ें →",
   },
   mar: {
@@ -46,6 +46,13 @@ export default function Index() {
         <div className="w-full">
           {/* Hero component */}
           <Hero />
+        </div>
+      </section>
+
+      {/* New benefits-like grid with image backgrounds */}
+      <section className="w-full max-w-7xl pt-6">
+        <div className="w-full">
+          <ImageBenefits />
         </div>
       </section>
 

--- a/server/node-build.ts
+++ b/server/node-build.ts
@@ -12,8 +12,8 @@ const distPath = path.join(__dirname, "../spa");
 // Serve static files
 app.use(express.static(distPath));
 
-// Handle React Router - serve index.html for all non-API routes
-app.get("*", (req, res) => {
+// Handle React Router - serve index.html for all non-API routes (Express v5)
+app.get("/*", (req, res) => {
   // Don't serve index.html for API routes
   if (req.path.startsWith("/api/") || req.path.startsWith("/health")) {
     return res.status(404).json({ error: "API endpoint not found" });


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user wanted to:
- Fix a non-working YouTube video in testimonials
- Add flip card functionality to testimonial cards activated by a key in the carousel component
- Show testimonial descriptions only when users click "more" button
- Increase card height and display video/image in more than half the card size
- Position title and "more" button below the media content

## Code changes

- **Theme Provider**: Added `ThemeProvider` from next-themes to App.tsx for dark/light mode support
- **Flip Card Functionality**: Enhanced `CardCarousel` component with `enableFlip` prop to enable card flipping on click
- **Testimonials Layout**: 
  - Increased card height to 384px (from 220px)
  - Added flip animation with 3D transform effects
  - Improved YouTube video embedding with iframe support
  - Enhanced media display to take more card space (h-64)
  - Repositioned title and "more" button below media content
- **New ImageBenefits Component**: Added investment-focused benefits section with image backgrounds
- **UI Improvements**: Added testimonials heading and improved spacing in AwardsMarquee
- **Server Route Fix**: Updated Express route pattern from `*` to `/*` for better compatibilityTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9c0c32021daa40b991037fe9237ef6a8/quantum-hub)

👀 [Preview Link](https://9c0c32021daa40b991037fe9237ef6a8-quantum-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9c0c32021daa40b991037fe9237ef6a8</projectId>-->
<!--<branchName>quantum-hub</branchName>-->